### PR TITLE
Add feature to reference upstreams in configuration

### DIFF
--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -69,13 +69,15 @@ const getOptimizedUpstreamOptions = ({type, options}) => {
   )
 }
 
-const getOptimizedUpstreams = ({pathRegExp, rulesets, upstreams}) => {
+const getOptimizedUpstreams = ({pathRegExp, rulesets, upstreams, upstreamsReferences}) => {
   const optimizedPathRegExp = {
     prefix: pathRegExp ? (pathRegExp.prefix || '') : '',
     sufix: pathRegExp ? (pathRegExp.sufix || '') : ''
   }
 
-  return upstreams.filter(upstream =>
+  const unreferencedUpstreams = getUnreferencedUpstreams(upstreams, upstreamsReferences)
+
+  return unreferencedUpstreams.filter(upstream =>
     upstream.enabled &&
     upstream.upstream &&
     upstream.upstream.type &&
@@ -148,4 +150,10 @@ const optimizePath = ({path}, pathRegExp) => {
     const finalPath = pathRegExp ? pathRegExp.prefix + p + pathRegExp.sufix : p
     return new RegExp(finalPath, 'i')
   })
+}
+
+function getUnreferencedUpstreams (upstreams, upstreamsReferences = {}) {
+  return upstreams.map(upstream => typeof upstream.upstream === 'object'
+    ? upstream
+    : Object.assign(upstream, {upstream: upstreamsReferences[upstream.upstream]}))
 }

--- a/test/utils/config.spec.js
+++ b/test/utils/config.spec.js
@@ -21,207 +21,153 @@ const geoips = [
 const agents = ['Chrome', 'Safari', 'Netscape']
 const paths = ['/one', '/two', '/three']
 
-const rulesets = {
-  first: {
-    cookie: [
-      {
-        name: 'step',
-        value: 'in'
+const upstreams = [
+  {
+    name: 'first',
+    enabled: true,
+    criteria: {
+      in: {
+        ruleset: ['first', 'third']
+      },
+      out: {
+        ruleset: ['second']
       }
-    ],
-    path: ['/step', '/walk', '/run'],
-    bucket: [{min: 0, max: 10}, {min: 45, max: 55}, {min: 80, max: 100}]
-  },
-  second: {
-    cookie: [
-      {
-        name: 'step',
-        value: 'out'
-      }
-    ],
-    agent: ['Chrome', 'Safari'],
-    bucket: [{min: 10, max: 45}, {min: 55, max: 80}]
-  },
-  third: {
-    agent: ['Netscape']
-  }
-}
-
-let firstUp = {
-  name: 'firstUp',
-  enabled: true,
-  criteria: {
-    in: {
-      ruleset: ['first', 'third']
     },
-    out: {
-      ruleset: ['second']
-    }
+    upstream: 'mindera'
   },
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com'
-    }
-  }
-}
-
-let secondUp = {
-  name: 'secondUp',
-  enabled: true,
-  criteria: {
-    in: {
-      ruleset: ['second', 'third']
-    }
+  {
+    name: 'second',
+    enabled: true,
+    criteria: {
+      in: {
+        ruleset: ['second', 'third']
+      }
+    },
+    upstream: 'mindera'
   },
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com'
-    }
-  }
-}
-
-let thirdUp = {
-  name: 'thirdUp',
-  enabled: true,
-  criteria: {
-    in: {
-      ruleset: ['second', 'third'],
-      agent: ['Firefox', 'Opera', 'Vivaldi']
-    }
+  {
+    name: 'third',
+    enabled: true,
+    criteria: {
+      in: {
+        ruleset: ['second', 'third'],
+        agent: ['Firefox', 'Opera', 'Vivaldi']
+      }
+    },
+    upstream: 'mindera'
   },
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com'
-    }
-  }
-}
-
-let fourthUp = {
-  name: 'fourthUp',
-  enabled: true,
-  criteria: {
-    in: {
-      and: [
-        {
-          path: paths
-        },
-        {
-          or: [
-            {
-              path: paths
-            }
-          ]
+  {
+    name: 'fourth',
+    enabled: true,
+    criteria: {
+      in: {
+        and: [
+          {
+            path: paths
+          },
+          {
+            or: [
+              {
+                path: paths
+              }
+            ]
+          }
+        ],
+        or: [
+          {
+            path: paths
+          },
+          {
+            and: [
+              {
+                path: paths
+              }
+            ]
+          }
+        ]
+      }
+    },
+    upstream: 'mindera'
+  },
+  {
+    name: 'fifth',
+    enabled: true,
+    upstream: 'mindera'
+  },
+  {
+    name: 'sixth',
+    enabled: true,
+    criteria: {
+      in: {
+        geoip: geoips,
+        agent: agents,
+        path: paths
+      }
+    },
+    upstream: 'mindera'
+  },
+  {
+    name: 'seventh',
+    enabled: true,
+    criteria: {},
+    upstream: {
+      type: 'serve',
+      options: {
+        host: 'www.mindera.com',
+        rewrite: {
+          expression: '(.*)',
+          to: '/noticias/atualidade'
         }
-      ],
-      or: [
-        {
-          path: paths
-        },
-        {
-          and: [
-            {
-              path: paths
-            }
-          ]
-        }
-      ]
-    }
-  },
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com'
-    }
-  }
-}
-
-let fifthUp = {
-  name: 'fifthUp',
-  enabled: true,
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com'
-    }
-  }
-}
-
-let sixthUp = {
-  name: 'sixthUp',
-  enabled: true,
-  criteria: {
-    in: {
-      geoip: geoips,
-      agent: agents,
-      path: paths
-    }
-  },
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com'
-    }
-  }
-}
-
-let seventhUp = {
-  name: 'seventhUp',
-  enabled: true,
-  criteria: {},
-  upstream: {
-    type: 'serve',
-    options: {
-      host: 'www.mindera.com',
-      rewrite: {
-        expression: '(.*)',
-        to: '/noticias/atualidade'
       }
     }
   }
+]
+
+const upstreamsReferences = {
+  mindera: {
+    type: 'serve',
+    options: {
+      host: 'www.mindera.com'
+    }
+  }
 }
 
-const getOptimizedUpstream = (upstream) => config.getOptimizedUpstreams({
+const optimizedUpstreams = config.getOptimizedUpstreams({
   pathRegExp: {
     prefix: '^',
     sufix: '([/?].*)?$'
   },
-  upstreams: [upstream]
-})[0]
-
-before(() => {
-  firstUp = getOptimizedUpstream(firstUp)
-  secondUp = getOptimizedUpstream(secondUp)
-  thirdUp = getOptimizedUpstream(thirdUp)
-  fourthUp = getOptimizedUpstream(fourthUp)
-  fifthUp = getOptimizedUpstream(fifthUp)
-  sixthUp = getOptimizedUpstream(sixthUp)
-  seventhUp = getOptimizedUpstream(seventhUp)
+  upstreams,
+  upstreamsReferences
 })
 
 describe('Evaluate configuration optimization', () => {
+  describe('Evaluate upstream references', function () {
+    it('Should set upstream when it is provided by name reference', () => {
+      expect(optimizedUpstreams[0].upstream).to.deep.equal(upstreamsReferences.mindera)
+    })
+  });
+
   describe('Evaluate rulesets concatenation', () => {
     describe('Evaluate survival of ruleset property', () => {
       it('Should keep property in criteria.in', () => {
-        expect(firstUp).to.have.deep.property('criteria.in.ruleset')
+        expect(optimizedUpstreams[0]).to.have.deep.property('criteria.in.ruleset')
       })
 
       it('Should keep property in criteria.out', () => {
-        expect(firstUp).to.have.deep.property('criteria.out.ruleset')
+        expect(optimizedUpstreams[0]).to.have.deep.property('criteria.out.ruleset')
       })
     })
 
     describe('Evaluate that properties from rulesets aren\'t being added to criteria', () => {
       it('Should not have properties from rulesets', () => {
-        expect(secondUp).to.not.have.deep.property('criteria.in.agent')
-        expect(secondUp).to.not.have.deep.property('criteria.in.bucket')
-        expect(secondUp).to.not.have.deep.property('criteria.in.cookie')
+        expect(optimizedUpstreams[1]).to.not.have.deep.property('criteria.in.agent')
+        expect(optimizedUpstreams[1]).to.not.have.deep.property('criteria.in.bucket')
+        expect(optimizedUpstreams[1]).to.not.have.deep.property('criteria.in.cookie')
       })
 
       it('Should keep property from own criteria and not override from ruleset', () => {
-        expect(thirdUp).to.have.deep.property('criteria.in.agent')
+        expect(optimizedUpstreams[2]).to.have.deep.property('criteria.in.agent')
           .and.to.have.lengthOf(3)
       })
     })
@@ -230,13 +176,13 @@ describe('Evaluate configuration optimization', () => {
   describe('Evaluate optimization of properties inside operators', () => {
     describe('Evaluate operator AND', () => {
       it('Should have properties and be optimized', () => {
-        expect(fourthUp).to.have.deep.property('criteria.in.and[0].path')
+        expect(optimizedUpstreams[3]).to.have.deep.property('criteria.in.and[0].path')
           .and.to.have.lengthOf(paths.length)
           .and.not.equal(paths)
       })
 
       it('Should have operator and have properties optimized', () => {
-        expect(fourthUp).to.have.deep.property('criteria.in.and[1].or[0].path')
+        expect(optimizedUpstreams[3]).to.have.deep.property('criteria.in.and[1].or[0].path')
           .and.to.have.lengthOf(paths.length)
           .and.not.equal(paths)
       })
@@ -244,13 +190,13 @@ describe('Evaluate configuration optimization', () => {
 
     describe('Evaluate operator OR', () => {
       it('Should have properties and be optimized', () => {
-        expect(fourthUp).to.have.deep.property('criteria.in.or[0].path')
+        expect(optimizedUpstreams[3]).to.have.deep.property('criteria.in.or[0].path')
           .and.to.have.lengthOf(paths.length)
           .and.not.equal(paths)
       })
 
       it('Should have operator and have properties optimized', () => {
-        expect(fourthUp).to.have.deep.property('criteria.in.or[1].and[0].path')
+        expect(optimizedUpstreams[3]).to.have.deep.property('criteria.in.or[1].and[0].path')
           .and.to.have.lengthOf(paths.length)
           .and.not.equal(paths)
       })
@@ -259,46 +205,46 @@ describe('Evaluate configuration optimization', () => {
 
   describe('Evaluate upstream without criteria', () => {
     it('Should have criteria property', () => {
-      expect(fifthUp).to.have.property('criteria')
+      expect(optimizedUpstreams[4]).to.have.property('criteria')
         .and.to.not.be.undefined
     })
 
     it('Should have criteria.in property and be undefined', () => {
-      expect(fifthUp).to.have.deep.property('criteria.in')
+      expect(optimizedUpstreams[4]).to.have.deep.property('criteria.in')
         .and.to.be.undefined
     })
 
     it('Should have criteria.out property and be undefined', () => {
-      expect(fifthUp).to.have.deep.property('criteria.out')
+      expect(optimizedUpstreams[4]).to.have.deep.property('criteria.out')
         .and.to.be.undefined
     })
   })
 
   describe('Evaluate properties optimizations', () => {
     it('Should have property geoip and same length but be different', () => {
-      expect(sixthUp).to.have.deep.property('criteria.in.geoip')
+      expect(optimizedUpstreams[5]).to.have.deep.property('criteria.in.geoip')
         .and.to.have.lengthOf(geoips.length)
         .and.not.equal(geoips)
     })
 
     it('Should have property agent and same length but be different', () => {
-      expect(sixthUp).to.have.deep.property('criteria.in.agent')
+      expect(optimizedUpstreams[5]).to.have.deep.property('criteria.in.agent')
         .and.to.have.lengthOf(agents.length)
         .and.not.equal(agents)
     })
 
     it('Should have property path and same length but be different', () => {
-      expect(sixthUp).to.have.deep.property('criteria.in.path')
+      expect(optimizedUpstreams[5]).to.have.deep.property('criteria.in.path')
         .and.to.have.lengthOf(paths.length)
         .and.not.equal(paths)
     })
 
     it('Should have property regExp in options.rewrite when rewrite is set', () => {
-      expect(seventhUp).to.have.deep.property('upstream.options.rewrite.regExp')
+      expect(optimizedUpstreams[6]).to.have.deep.property('upstream.options.rewrite.regExp')
     })
 
     it('Shouldn\'t have property options.rewrite nor rewrite.regExp when rewrite isn\'t set', () => {
-      expect(sixthUp).to.not.have.deep.property('upstream.options.rewrite')
+      expect(optimizedUpstreams[5]).to.not.have.deep.property('upstream.options.rewrite')
         .and.to.not.have.deep.property('upstream.options.rewrite.regExp')
     })
   })


### PR DESCRIPTION
In our configuration, we can do this:
```javascript
upstreams: [
  {
    name: 'first',
    enabled: true,
    criteria: {
      in: {
        ruleset: ['first', 'third']
      },
      out: {
        ruleset: ['second']
      }
    },
    upstream: 'mindera'
  }
],
upstreamsReferences: {
  mindera: {
    type: 'serve',
    options: {
      host: 'www.mindera.com'
    }
  }
}
```

This adds more reusability, reduces the config size and increases the config legibility.